### PR TITLE
Add support for local folders

### DIFF
--- a/ClassLibrary/ClassLibrary.csproj
+++ b/ClassLibrary/ClassLibrary.csproj
@@ -8,9 +8,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>ClassLibrary</RootNamespace>
     <AssemblyName>ClassLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ClassLibrary/P4Command.cs
+++ b/ClassLibrary/P4Command.cs
@@ -233,9 +233,17 @@ namespace ClassLibrary
 
 		public void RunP4Set(string solutionDirectory, out string P4Port, out string P4User, out string P4Client, out string verbose)
 		{
+			string P4Config;
+			RunP4Set(solutionDirectory, out P4Port, out P4User, out P4Client, out P4Config, out verbose);
+		}
+
+
+		public void RunP4Set(string solutionDirectory, out string P4Port, out string P4User, out string P4Client, out string P4Config, out string verbose)
+		{
 			P4Port = "";
 			P4User = "";
 			P4Client = "";
+			P4Config = "";
 			verbose = "";
 
 			if (solutionDirectory == null || solutionDirectory == "")
@@ -290,6 +298,16 @@ namespace ClassLibrary
 						}
 
 						P4Client = line.Substring(9);
+					}
+					else if (line.Contains("P4CONFIG="))
+					{
+						int pos = line.IndexOf(" (");
+						if (pos >= 0)  // if the line contains " (" then strip it and the following text
+						{
+							line = line.Remove(pos).Trim();
+						}
+
+						P4Config = line.Substring(9);
 					}
 				}
 			}

--- a/SharedProject/SccProvider.cs
+++ b/SharedProject/SccProvider.cs
@@ -439,21 +439,21 @@ namespace P4SimpleScc
 					IVsRegisterScciProvider rscp = (IVsRegisterScciProvider)GetService(typeof(IVsRegisterScciProvider));
 					rscp.RegisterSourceControlProvider(GuidList.guidSccProvider);
 
-					GetSolutionFileName();
-
-					if (!bSolutionLoadedOutputDone && (solutionDirectory != null) && (solutionDirectory.Length > 0))
-					{
-						string message = String.Format("Loaded solution: {0}\n", solutionFile);
-						SccProvider.P4SimpleSccOutput(message);
-
-						bSolutionLoadedOutputDone = true;
-					}
+					GetSolutionFileName();					
 
 					SetP4SettingsForSolution(solutionDirectory);
 
 					ServerConnect();
 				}
-			}
+
+                if (!bSolutionLoadedOutputDone && (solutionDirectory != null) && (solutionDirectory.Length > 0))
+                {
+                    string message = String.Format("Loaded solution: {0}\n", solutionFile);
+                    SccProvider.P4SimpleSccOutput(message);
+
+                    bSolutionLoadedOutputDone = true;
+                }
+            }
 
 			return VSConstants.S_OK;
 		}

--- a/SharedProject/SccProviderService.cs
+++ b/SharedProject/SccProviderService.cs
@@ -223,7 +223,7 @@ namespace P4SimpleScc
 
 		public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
 		{
-			return OnAfterCloseSolutionOrFolder();
+			return OnAfterOpenSolutionOrFolder();
 		}
 
 		public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)


### PR DESCRIPTION
Hello!

Thanks for your extension, it does exactly what I expect from a P4 IDE integration. Here's a little contribution that allows it to work with "solutionless" folders, i.e. the "Open local folder" flow from the splash screen. This works because `IVsSolution` returns the folder path as solution name, as if it was the solution. To account for the fact that in this flow we have no way to store user preferences (like we do in the solution case), I've implemented detection of [`P4CONFIG` usage](https://www.perforce.com/manuals/v23.1/cmdref/Content/CmdRef/P4CONFIG.html), to make the automatic mode a more robust default.

One could argue that the `P4CONFIG` detection should run also in the solution case, as the subsequent user preference load from the solution should be able to overwrite the detected `P4CONFIG` defaults, but I don't need that in my case, so I'll leave that as a future opportunity.